### PR TITLE
Fix/check tensor

### DIFF
--- a/lucent/optvis/hooks.py
+++ b/lucent/optvis/hooks.py
@@ -23,7 +23,10 @@ class ModuleHook:
     def hook_fn(self, module: nn.Module, input: torch.Tensor, output: torch.Tensor):
         if torch.is_tensor(output):
             device = output.device
-            self._features[str(device)] = output
+        elif isinstance(output, tuple):
+            # happens for multi-head attention layers in ViTs
+            device = output[0].device
+        self._features[str(device)] = output
 
     def close(self):
         self.hook.remove()

--- a/lucent/optvis/hooks.py
+++ b/lucent/optvis/hooks.py
@@ -21,8 +21,9 @@ class ModuleHook:
             return torch.nn.parallel.gather([self._features[k] for k in keys], keys[0])
 
     def hook_fn(self, module: nn.Module, input: torch.Tensor, output: torch.Tensor):
-        device = output.device
-        self._features[str(device)] = output
+        if torch.is_tensor(output):
+            device = output.device
+            self._features[str(device)] = output
 
     def close(self):
         self.hook.remove()


### PR DESCRIPTION
For ViTs, the multi-head attention layers do not return tensors as output in their forward pass, but tuples.

Since we currently ignore the multi-head attention layers, we could just ignore this case, but maybe we want to support them later, so I just store the outputs as well.

This is just a suggestion, feel free to handle this differently if you have a better idea :) 