### PR TITLE
Add FFT MACO image parameterisation

### DIFF
--- a/lucent/optvis/param/images.py
+++ b/lucent/optvis/param/images.py
@@ -13,21 +13,25 @@
 # limitations under the License.
 # ==============================================================================
 
-"""High-level wrapper for paramaterizing images."""
+"""High-level wrapper for parameterizing images."""
 
 from __future__ import absolute_import, division, print_function
 
+from typing import Literal
+
 from lucent.optvis.param.color import to_valid_rgb
-from lucent.optvis.param.spatial import fft_image, pixel_image
+from lucent.optvis.param.spatial import fft_image, pixel_image, fft_maco_image
 
 
-def image(w, h=None, sd=None, batch=None, decorrelate=True, fft=True, channels=None):
+def image(w, h=None, batch=None, decorrelate=True,
+          mode: Literal["pixel", "fft", "maco_fft"] = "fft", channels=None,
+          **inner_kwargs):
     h = h or w
     batch = batch or 1
     ch = channels or 3
     shape = [batch, ch, h, w]
-    param_f = fft_image if fft else pixel_image
-    params, image_f = param_f(shape, sd=sd)
+    param_f = {"pixel": pixel_image, "fft": fft_image, "fft_maco": fft_maco_image}[mode]
+    params, image_f = param_f(shape, **inner_kwargs)
     if channels:
         output = to_valid_rgb(image_f, decorrelate=False)
     else:

--- a/lucent/optvis/param/spatial.py
+++ b/lucent/optvis/param/spatial.py
@@ -76,3 +76,39 @@ def fft_image(shape, sd=None, decay_power=1):
         return image
 
     return [spectrum_real_imag_t], inner
+
+
+def fft_maco_image(shape, spectrum_magnitude: torch.Tensor):
+    batch, channels, h, w = shape
+    freqs = rfft2d_freqs(h, w)
+
+    init_phase_shape = (
+        (batch, channels) + freqs.shape
+    )
+
+    assert spectrum_magnitude.ndim == 3
+    spectrum_magnitude = spectrum_magnitude[None].repeat(batch, 1, 1, 1)
+
+    assert spectrum_magnitude.shape == init_phase_shape, (
+        f"Shape of magnitude {spectrum_magnitude.shape} does not "
+        f"match phase {init_phase_shape}.")
+
+    spectrum_phase = (
+        (torch.rand(init_phase_shape) * np.pi).to(device)
+    )
+
+    spectrum_phase = spectrum_phase.requires_grad_(True)
+
+    def inner():
+        if TORCH_VERSION <= "1.7.0":
+            raise NotImplementedError("MACO FFT requires torch version >= 1.7.0")
+
+        import torch.fft
+
+        spectrum = torch.polar(spectrum_magnitude, spectrum_phase)
+        image = torch.fft.irfftn(spectrum, s=(h, w), norm="ortho")
+        image = image[:batch, :channels, :h, :w]
+
+        return image
+
+    return [spectrum_phase], inner


### PR DESCRIPTION
This implements the image parametrization proposed in ["Unlocking Feature Visualization for Deeper Networks with MAgnitude Constrained Optimization"](https://arxiv.org/abs/2306.06805).