### PR TITLE
Improve transformations and fix bug introduced in #26

### DIFF
--- a/lucent/optvis/render.py
+++ b/lucent/optvis/render.py
@@ -81,7 +81,7 @@ def render_vis(
     optimizer = optimizer_f(params)
 
     if transforms is None:
-        transforms = transform.get_standard_transforms(max(image_shape))
+        transforms = transform.get_standard_transforms(image_shape, fixed_image_size)
     transforms = transforms.copy()
 
     if preprocess:
@@ -92,19 +92,6 @@ def render_vis(
             # Assume we use normalization for torchvision.models
             # See https://pytorch.org/docs/stable/torchvision/models.html
             transforms.append(transform.normalize())
-
-    # Upsample images smaller than 224
-    image_shape = image_f().shape
-    if fixed_image_size is not None:
-        new_size = fixed_image_size
-    elif image_shape[2] < 224 or image_shape[3] < 224:
-        new_size = 224
-    else:
-        new_size = None
-    if new_size:
-        transforms.append(
-            torch.nn.Upsample(size=new_size, mode="bilinear", align_corners=True)
-        )
 
     transform_f = transform.compose(transforms)
 

--- a/lucent/optvis/render.py
+++ b/lucent/optvis/render.py
@@ -41,6 +41,7 @@ class RenderInterrupt(Exception):
 def render_vis(
     model: nn.Module,
     objective_f: ObjectiveT,
+    target_image_shape: Optional[Tuple[int, int]],
     param_f: Optional[ParamT] = None,
     optimizer_f: Optional[OptimizerT] = None,
     transforms: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
@@ -52,7 +53,6 @@ def render_vis(
     save_image: bool = False,
     image_name: Optional[str] = None,
     show_inline: bool = False,
-    fixed_image_size: Optional[int] = None,
     redirected_activation_warmup: int = 16,
     iteration_callback: Optional[
         Callable[
@@ -81,7 +81,7 @@ def render_vis(
     optimizer = optimizer_f(params)
 
     if transforms is None:
-        transforms = transform.get_standard_transforms(image_shape, fixed_image_size)
+        transforms = transform.get_standard_transforms(image_shape, target_image_shape)
     transforms = transforms.copy()
 
     if preprocess:

--- a/lucent/optvis/transform.py
+++ b/lucent/optvis/transform.py
@@ -15,39 +15,35 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Callable, List, Sequence
+from typing import Callable, List, Sequence, Tuple, Optional
 
 import kornia
 import numpy as np
 import torch
 import torch.nn.functional as F
-from kornia.geometry.transform import translate
 from torchvision.transforms import Normalize
 
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 KORNIA_VERSION = kornia.__version__
 
 
-def jitter(d: int, crop: bool = False) -> Callable[[torch.Tensor], torch.Tensor]:
-    assert d > 1, "Jitter parameter d must be more than 1, currently {}".format(d)
+def jitter(d: int) -> Callable[[torch.Tensor], torch.Tensor]:
+    assert d > 0, "Jitter parameter d must be more than 0, currently {}".format(d)
 
     def inner(image_t: torch.Tensor) -> torch.Tensor:
+        w, h = image_t.shape[-2:]
         sx = np.random.choice([-1, 1])
         sy = np.random.choice([-1, 1])
-        dx = np.random.choice(d)
-        dy = np.random.choice(d)
-        image_t = translate(
-            image_t, torch.tensor([[sx * dx, sy * dy]]).float().to(device))
+        dx = np.random.choice(d + 1)
+        dy = np.random.choice(d + 1)
+        if sx > 0:
+            image_t = image_t[..., dx:, :].contiguous()
+        else:
+            image_t = image_t[..., : w - dx, :].contiguous()
 
-        if crop:
-            if sx == 1 and dx > 0:
-                image_t = image_t[:, :, :-dx, :]
-            else:
-                image_t = image_t[:, :, dx:, :]
-            if sy == 1 and dy > 0:
-                image_t = image_t[:, :, :, :-dy]
-            else:
-                image_t = image_t[:, :, :, dy:]
+        if sy > 0:
+            image_t = image_t[..., dy:, :].contiguous()
+        else:
+            image_t = image_t[..., : h - dy, :].contiguous()
 
         return image_t
 
@@ -71,7 +67,9 @@ def pad(
     return inner
 
 
-def random_scale(scales: Sequence[float]) -> Callable[[torch.Tensor], torch.Tensor]:
+def random_scale(
+    scales: Sequence[float], pad_constant_value: float = 0.5
+) -> Callable[[torch.Tensor], torch.Tensor]:
     def inner(image_t: torch.Tensor) -> torch.Tensor:
         scale = np.random.choice(scales)
         shp = image_t.shape[2:]
@@ -81,7 +79,7 @@ def random_scale(scales: Sequence[float]) -> Callable[[torch.Tensor], torch.Tens
         upsample = torch.nn.Upsample(
             size=scale_shape, mode="bilinear", align_corners=True
         )
-        return F.pad(upsample(image_t), [pad_y, pad_x] * 2)
+        return F.pad(upsample(image_t), [pad_y, pad_x] * 2, value=pad_constant_value)
 
     return inner
 
@@ -101,10 +99,12 @@ def random_rotate(
         center = torch.ones(b, 2)
         center[..., 0] = (image_t.shape[3] - 1) / 2
         center[..., 1] = (image_t.shape[2] - 1) / 2
-        M = kornia.geometry.transform.get_rotation_matrix2d(
-            center, angle, scale).to(device)
+        M = kornia.geometry.transform.get_rotation_matrix2d(center, angle, scale).to(
+            image_t.device
+        )
         rotated_image = kornia.geometry.transform.warp_affine(
-            image_t.float(), M, dsize=(h, w))
+            image_t.float(), M, dsize=(h, w)
+        )
         return rotated_image
 
     return inner
@@ -150,17 +150,42 @@ def center_crop(h: int, w: int) -> Callable[[torch.Tensor], torch.Tensor]:
     If the image is smaller than the given height and width, then the image is
     returned as is.
     """
+
     def inner(x: torch.Tensor) -> torch.Tensor:
         if x.shape[2] >= h and x.shape[3] >= w:
             oy = (x.shape[2] - h) // 2
             ox = (x.shape[3] - w) // 2
 
-            return x[:, :, oy:oy + h, ox:ox + w]
+            return x[:, :, oy : oy + h, ox : ox + w]
         elif x.shape[2] < h and x.shape[3] < w:
             return x
         else:
-            raise ValueError("Either both width and height must be smaller than the "
-                             "image, or both must be larger.")
+            raise ValueError(
+                "Either both width and height must be smaller than the "
+                "image, or both must be larger."
+            )
+
+    return inner
+
+
+def resize(
+    h: int, w: int, interpolation: str = "bilinear"
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Resize the image to at least the given height and width.
+
+    Does not change the image if it is larger than the given height and width.
+
+    Args:
+        h: The height to resize to.
+        w: The width to resize to.
+        interpolation: The interpolation method to use. Must be one of
+            "nearest", "bilinear", or "bicubic".
+    """
+
+    def inner(x: torch.Tensor) -> torch.Tensor:
+        if x.shape[2] >= h and x.shape[3] >= w:
+            return x
+        return F.interpolate(x, (h, w), mode=interpolation, align_corners=True)
 
     return inner
 
@@ -173,12 +198,21 @@ def preprocess_inceptionv1() -> Callable[[torch.Tensor], torch.Tensor]:
     return lambda x: x * 255 - 117
 
 
-def get_standard_transforms(size: int) -> List[ Callable[[torch.Tensor], torch.Tensor]]:
-    unit = size // 32
-    return [
+def get_standard_transforms(
+    source_shape: Tuple[int, int], target_shape: Optional[Tuple[int, int]] = None
+) -> List[Callable[[torch.Tensor], torch.Tensor]]:
+    unit = max(source_shape) // 32
+
+    augmentations = [
         pad(3 * unit, mode="constant", constant_value=0.5),
         jitter(2 * unit),
         random_scale([1 + (i - 5) / 50.0 for i in range(11)]),
         random_rotate(list(range(-10, 11)) + 5 * [0]),
         jitter(unit),
     ]
+
+    if target_shape:
+        augmentations.append(center_crop(*target_shape))
+        augmentations.append(resize(*target_shape))
+
+    return augmentations


### PR DESCRIPTION
The most important changes of this PR are that the `center_crop` at the end of the standard transformations will now correctly take different input image resolutions of the network into account and the `jitter` augmentation now performs random cropping instead of just random translations in one direction (positive half-plane).

- Improve transformations and fix bug introduced in #26
- Rename argument in render
