### PR TITLE
Add channel objective for ViTs/attention layers

### DIFF
--- a/lucent/optvis/objectives.py
+++ b/lucent/optvis/objectives.py
@@ -384,14 +384,14 @@ def vit_channel(
     n_channel: int,
     channel_mode: Union[Literal["first"], Literal["last"]] = "first",
     batch=None,
-):
+) -> WrapObjectiveInnerT:
     """Visualize a single channel of a ViT/self-attention layer."""
 
-    if channel_mode != "first":
-        raise NotImplementedError("Only channel first format is supported for now")
+    if channel_mode not in ("first", "last"):
+        raise ValueError("channel_mode must be 'first' or 'last.")
 
     @handle_batch(batch)
-    def inner(model):
+    def inner(model: nn.Module) -> torch.Tensor:
         activation = model(layer)
         if activation.ndim != 3:
             raise RuntimeError(
@@ -400,10 +400,8 @@ def vit_channel(
 
         if channel_mode == "first":
             activation = activation[:, n_channel, :]
-        elif channel_mode == "last":
-            activation = activation[:, :, n_channel]
         else:
-            raise ValueError("channel_mode must be 'first' or 'last.")
+            activation = activation[:, :, n_channel]
 
         activation = activation[:, 1:]  # Exclude CLS token
         loss = -activation.mean()

--- a/lucent/optvis/objectives.py
+++ b/lucent/optvis/objectives.py
@@ -397,16 +397,16 @@ def vit_channel(
             raise RuntimeError(
                 "Shapes of activations do not match expected shape for objective."
             )
-        if activation.shape[0] == 1:
-            activation = activation[0]
-        elif activation.shape[1] == 1:
-            activation = activation[:, 0]
+
+        if channel_mode == "first":
+            activation = activation[:, n_channel, :]
+        elif channel_mode == "last":
+            activation = activation[:, :, n_channel]
         else:
-            raise RuntimeError(
-                "Shapes of activations do not match expected shape for "
-                "objective. Found shape: {}".format(activation.shape)
-            )
-        loss = -activation[1:, n_channel].mean(dim=0)  # Exclude CLS token
+            raise ValueError("channel_mode must be 'first' or 'last.")
+
+        activation = activation[:, 1:]  # Exclude CLS token
+        loss = -activation.mean()
         return loss
 
     return inner, [layer]

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -92,6 +92,7 @@ def assert_gradient_descent(
             end_value = objective_f(T)
         if start_value > end_value:
             return
+
     raise AssertionError(
         "Gradient descent did not improve objective value: {0} -> {1}".format(
             start_value, end_value))
@@ -135,7 +136,7 @@ def test_channel(model_and_channel_mode):
 )
 def test_vit_channel(model):
     objective = objectives.vit_channel("encoder_layers_encoder_layer_2_mlp_3", 0)
-    assert_gradient_descent(objective, model, 224)
+    assert_gradient_descent(objective, model)
 
 
 @pytest.mark.parametrize(
@@ -199,7 +200,7 @@ def test_sum(inceptionv1_model):
 
 
 def test_linear_transform(inceptionv1_model):
-    objective = 1 + 1 * -objectives.channel("mixed4a", 0) / 1 - 1
+    objective = 1 + 1 * -objectives.channel("mixed4a_pool_reduce_pre_relu_conv", 0) / 1 - 1
     assert_gradient_descent(objective, inceptionv1_model)
 
 

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -27,7 +27,7 @@ from torchvision import models
 set_seed(137)
 
 
-NUM_STEPS = 5
+NUM_STEPS = 20
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -95,7 +95,9 @@ def assert_gradient_descent(
 
     raise AssertionError(
         "Gradient descent did not improve objective value: {0} -> {1}".format(
-            start_value, end_value))
+            start_value, end_value
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -200,7 +202,9 @@ def test_sum(inceptionv1_model):
 
 
 def test_linear_transform(inceptionv1_model):
-    objective = 1 + 1 * -objectives.channel("mixed4a_pool_reduce_pre_relu_conv", 0) / 1 - 1
+    objective = (
+        1 + 1 * -objectives.channel("mixed4a_pool_reduce_pre_relu_conv", 0) / 1 - 1
+    )
     assert_gradient_descent(objective, inceptionv1_model)
 
 
@@ -256,7 +260,11 @@ def test_blur_input_each_step(inceptionv1_model):
 def test_channel_interpolate(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
     objective = objectives.channel_interpolate(
-        "mixed4a", 465, "mixed4a", 460, channel_mode=channel_mode
+        "mixed4a_pool_reduce_pre_relu_conv",
+        465,
+        "mixed4a_pool_reduce_pre_relu_conv",
+        460,
+        channel_mode=channel_mode,
     )
     assert_gradient_descent(objective, model)
 
@@ -292,7 +300,9 @@ def test_direction(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
     direction = torch.rand(512) * 1000
     objective = objectives.direction(
-        layer="mixed4c", direction=direction, channel_mode=channel_mode
+        layer="mixed4c_pool_reduce_pre_relu_conv",
+        direction=direction,
+        channel_mode=channel_mode,
     )
     assert_gradient_descent(objective, model)
 

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import torch
 
+import lucent.optvis.objectives
 from lucent.modelzoo import inceptionv1
 from lucent.optvis import objectives, param, render
 from lucent.util import set_seed
@@ -69,8 +70,12 @@ def vit_b_16_model():
     return model
 
 
-def assert_gradient_descent(objective, model):
-    params, image = param.image(224, batch=2)
+def assert_gradient_descent(
+    objective: lucent.optvis.objectives.ObjectiveT,
+    model: torch.nn.Module,
+    input_size: int = 224,
+):
+    params, image = param.image(input_size, batch=2)
     optimizer = torch.optim.Adam(params, lr=0.05)
     with render.ModelHook(model, image) as T:
         objective_f = objectives.as_objective(objective)
@@ -123,10 +128,8 @@ def test_channel(model_and_channel_mode):
     ],
 )
 def test_vit_channel(model):
-    objective = objectives.vit_channel(
-        "encoder_layers_encoder_layer_2_mlp_3", 0
-    )
-    assert_gradient_descent(objective, model)
+    objective = objectives.vit_channel("encoder_layers_encoder_layer_2_mlp_3", 0)
+    assert_gradient_descent(objective, model, 224)
 
 
 @pytest.mark.parametrize(

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -260,11 +260,7 @@ def test_blur_input_each_step(inceptionv1_model):
 def test_channel_interpolate(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
     objective = objectives.channel_interpolate(
-        "mixed4a_pool_reduce_pre_relu_conv",
-        465,
-        "mixed4a_pool_reduce_pre_relu_conv",
-        460,
-        channel_mode=channel_mode,
+        "mixed4a", 465, "mixed4a", 460, channel_mode=channel_mode
     )
     assert_gradient_descent(objective, model)
 
@@ -300,9 +296,7 @@ def test_direction(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
     direction = torch.rand(512) * 1000
     objective = objectives.direction(
-        layer="mixed4c_pool_reduce_pre_relu_conv",
-        direction=direction,
-        channel_mode=channel_mode,
+        layer="mixed4c", direction=direction, channel_mode=channel_mode
     )
     assert_gradient_descent(objective, model)
 

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -265,9 +265,9 @@ def test_channel_interpolate(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
     objective = objectives.channel_interpolate(
         "mixed4a_pool_reduce_pre_relu_conv",
-        465,
+        32,
         "mixed4a_pool_reduce_pre_relu_conv",
-        460,
+        33,
         channel_mode=channel_mode,
     )
     assert_gradient_descent(objective, model)
@@ -304,7 +304,7 @@ def test_diversity(model_and_channel_mode):
 )
 def test_direction(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
-    direction = torch.rand(512) * 1000
+    direction = torch.rand(64) * 1000
     objective = objectives.direction(
         layer="mixed4c_pool_reduce_pre_relu_conv",
         direction=direction,
@@ -322,7 +322,7 @@ def test_direction(model_and_channel_mode):
 )
 def test_direction_neuron(model_and_channel_mode):
     model, channel_mode = model_and_channel_mode
-    direction = torch.rand(512) * 1000
+    direction = torch.rand(64) * 1000
     objective = objectives.direction_neuron(
         layer="mixed4c_pool_reduce_pre_relu_conv",
         direction=direction,

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -49,10 +49,10 @@ def channel_last_conv_linear_model_and_channel_mode():
             super(FCLinearModel, self).__init__()
             self.mixed3a_1x1_pre_relu_conv = torch.nn.Linear(3, 64, bias=False)
             self.mixed4a_pool_reduce_pre_relu_conv = torch.nn.Linear(
-                64, 480, bias=False
+                64, 64, bias=False
             )
             self.mixed4c_pool_reduce_pre_relu_conv = torch.nn.Linear(
-                480, 512, bias=False
+                64, 512, bias=False
             )
             self.relu = torch.nn.ReLU()
 

--- a/tests/optvis/test_objectives.py
+++ b/tests/optvis/test_objectives.py
@@ -52,7 +52,7 @@ def channel_last_conv_linear_model_and_channel_mode():
                 64, 64, bias=False
             )
             self.mixed4c_pool_reduce_pre_relu_conv = torch.nn.Linear(
-                64, 512, bias=False
+                64, 64, bias=False
             )
             self.relu = torch.nn.ReLU()
 


### PR DESCRIPTION
Note: For some reason, this PR uncovered some instability in the unit tests of the objectives. Because of the ReLU activation used by some of the targeted layers in these tests, the optimization of any objective might fail if the activations of the seed image are stuck at 0.